### PR TITLE
Fix for segfault if sbcl.core can't be found in the same folder as sbcl.e

### DIFF
--- a/src/runtime/runtime.c
+++ b/src/runtime/runtime.c
@@ -240,6 +240,9 @@ search_for_core ()
                 strcpy(dotPointer,".core");
                 lookhere = exe_path;
                 core = copied_existing_filename_or_null(lookhere);
+                if (!core) {
+                    lose("can't find core file at %s\n", lookhere);
+                }
                 return core;
             }
         }


### PR DESCRIPTION
Fix for segfault if sbcl.core can't be found in the same folder as sbcl.exe. See previous issue for explanation.
